### PR TITLE
feat: Bagisto 2.4.x / UnoPim 2.1.x compatibility and import fixes (v1.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This changelog documents updates implemented in the forked repository: [Bagisto REST API](https://github.com/bagisto/rest-api).
 These updates have been applied to the forked REST API.
-## v1.0.5 (June 18, 2026) - Release
+## v1.0.2 (June 22, 2026) - Release
 
 #### Update
 - Compatibility with Bagisto 2.4.x and the UnoPim v2.1.x connector.
@@ -13,10 +13,10 @@ These updates have been applied to the forked REST API.
 - Configurable variants: resolve variant SKUs from storage and skip missing ones so the bulk import no longer fails on an unresolved variant.
 
 ## v1.0.1 (January 30, 2025) - Release
-#### Improvements  
-- **Category Import**: Enhanced ID-based processing and implemented batch retry handling for more reliable imports.  
+#### Improvements
+- **Category Import**: Enhanced ID-based processing and implemented batch retry handling for more reliable imports.
 
-#### New Features  
+#### New Features
 - **S3 Compatibility**: Added support for both S3 protocol and S3 URLs within the same bucket to ensure seamless integration.
 
 ## v1.0.0 (January 20, 2025) - Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This changelog documents updates implemented in the forked repository: [Bagisto REST API](https://github.com/bagisto/rest-api).
 These updates have been applied to the forked REST API.
+## v1.0.5 (June 18, 2026) - Release
+
+#### Update
+- Compatibility with Bagisto 2.4.x and the UnoPim v2.1.x connector.
+
+#### Fixed
+- Exception handler method visibility changed from `private` to `protected` for compatibility with Bagisto 2.4.x.
+- Product image import: only use the S3 disk when AWS credentials are configured (an empty key no longer triggers the uninstalled S3 driver), and update image encoding to the Intervention Image v3 API.
+- Configurable variants: resolve variant SKUs from storage and skip missing ones so the bulk import no longer fails on an unresolved variant.
+
 ## v1.0.1 (January 30, 2025) - Release
 #### Improvements  
 - **Category Import**: Enhanced ID-based processing and implemented batch retry handling for more reliable imports.  

--- a/README.md
+++ b/README.md
@@ -1,51 +1,93 @@
 # Bagisto REST API
 
-<p>Bagisto REST API is a medium to use the features of the core Bagisto System. By using Bagisto REST API, you can integrate your application to serve the default content of Bagisto.</p>
+Bagisto REST API is a medium to use the features of the core Bagisto system. By using the Bagisto REST API, you can integrate your application to serve the default content of Bagisto.
 
-### 1. Requirements:
+## 1. Requirements
 
-* **Bagisto**: v2.2.x
+- **Bagisto:** v2.4.x
+- **PHP:** ^8.3
 
-### 2. Installation:
+## 2. Installation
 
-#### Install the stable version of Bagisto Rest API from your console using the below command:
-~~~
+### Option A — Composer (recommended)
+
+Install the package via Composer:
+
+```bash
 composer require unopim/bagisto-rest-api
-~~~
+```
 
-##### Add below options in the .env file (i.e. http://localhost/public your domain):
+### Option B — Manual (place the package in `packages/Webkul`)
 
-~~~
-SANCTUM_STATEFUL_DOMAINS=http://localhost/public
-~~~
+Use this when you want to keep the package source inside your project (for example, a fork you maintain).
 
-##### To configure the REST API L5-Swagger Documentation run below command:
+1. Put the package source in `packages/Webkul/RestApi`:
 
-~~~
+   ```bash
+   git clone https://github.com/unopim/bagisto-rest-api.git packages/Webkul/RestApi
+   rm -rf packages/Webkul/RestApi/.git
+   ```
+
+2. Register the namespace in the root `composer.json` under `autoload.psr-4`:
+
+   ```json
+   "Webkul\\RestApi\\": "packages/Webkul/RestApi/src"
+   ```
+
+3. Register the service provider in `bootstrap/providers.php`:
+
+   ```php
+   Webkul\RestApi\Providers\RestApiServiceProvider::class,
+   ```
+
+4. Install the L5-Swagger dependency and refresh the autoloader:
+
+   ```bash
+   composer require darkaonline/l5-swagger:^8.5
+   composer dump-autoload
+   ```
+
+### Configure (both options)
+
+Add your application's domain to the `.env` file so Sanctum can authenticate stateful requests. Use the **host** only (optionally `host:port`) — do not include the scheme or path:
+
+```dotenv
+SANCTUM_STATEFUL_DOMAINS=localhost
+```
+
+Publish the L5-Swagger configuration and generate the API documentation:
+
+```bash
 php artisan bagisto-rest-api:install
-~~~
+```
 
-##### To check the Admin end API documentation:
+> **Manual install only:** because the package lives in `packages/Webkul/RestApi` (not `vendor/`), open the published `config/l5-swagger.php` and change the annotation paths from `base_path('vendor/unopim/bagisto-rest-api/src/Docs/...')` to `base_path('packages/Webkul/RestApi/src/Docs/...')`, then regenerate the docs: `php artisan l5-swagger:generate --all`.
 
-~~~
-http://localhost/public/api/admin/documentation
-~~~
+Clear the caches:
 
-##### To check the Shop end API documentation:
+```bash
+php artisan optimize:clear
+```
 
-~~~
-http://localhost/public/api/shop/documentation
-~~~
+## 3. API Documentation
 
-### 3. Using Bulk Product API with Queues
+Open the following URLs in your browser (replace the host with your application's URL):
 
-To enable the **Bulk Product API** to run using queues, update your `.env` file:
+- **Admin:** `http://localhost/api/admin/documentation`
+- **Shop:** `http://localhost/api/shop/documentation`
 
-```sh
-QUEUE_DRIVER=database
+## 4. Bulk Product API (Queues)
+
+The Bulk Product API processes products asynchronously through the queue. Set the queue connection in your `.env`:
+
+```dotenv
 QUEUE_CONNECTION=database
 ```
 
-This ensures that bulk operations are processed asynchronously using the queue system.
+Then run a queue worker so the dispatched bulk jobs are processed:
 
-* You can check the <a href="https://github.com/DarkaOnLine/L5-Swagger"> L5-Swagger </a> guidelines too regarding the configuration the API documentation.
+```bash
+php artisan queue:work
+```
+
+> See the [L5-Swagger](https://github.com/DarkaOnLine/L5-Swagger) documentation for more details on configuring the API documentation.

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -32,7 +32,7 @@ class Handler extends BaseHandler
     /**
      * Handle the authentication exception.
      */
-    private function handleAuthenticationException(): void
+    protected function handleAuthenticationException(): void
     {
         $this->renderable(function (AuthenticationException $exception, Request $request) {
             $nameSpace = $request->is(config('app.admin_url').'/*') ? 'admin' : 'shop';
@@ -54,7 +54,7 @@ class Handler extends BaseHandler
     /**
      * Handle the http exceptions.
      */
-    private function handleHttpException(): void
+    protected function handleHttpException(): void
     {
         $this->renderable(function (HttpException $exception, Request $request) {
             $nameSpace = $request->is(config('app.admin_url').'/*') ? 'admin' : 'shop';
@@ -77,7 +77,7 @@ class Handler extends BaseHandler
     /**
      * Handle the server exceptions.
      */
-    private function handleServerException(): void
+    protected function handleServerException(): void
     {
         $this->renderable(function (Throwable $throwable, Request $request) {
             $nameSpace = $request->is(config('app.admin_url').'/*') ? 'admin' : 'shop';
@@ -97,7 +97,7 @@ class Handler extends BaseHandler
     /**
      * Handle validation exceptions.
      */
-    private function handleValidationException(): void
+    protected function handleValidationException(): void
     {
         $this->renderable(function (ValidationException $exception, Request $request) {
             return parent::convertValidationExceptionToResponse($exception, $request);

--- a/src/Helpers/Importers/Product/Importer.php
+++ b/src/Helpers/Importers/Product/Importer.php
@@ -117,11 +117,49 @@ class Importer extends BaseImporter
 
         $this->saveFlatData($flatData);
 
+        $this->resolveConfigurableVariants($configurableVariants);
+
         $this->saveConfigurableVariants($configurableVariants);
 
         $this->saveLinks($links);
 
         return true;
+    }
+
+    /**
+     * Load variant SKUs into storage and drop any variant that does not exist, so
+     * configurable linking resolves existing variants instead of failing on a
+     * missing one (e.g. when only the configurable parent is in the batch).
+     */
+    protected function resolveConfigurableVariants(array &$configurableVariants): void
+    {
+        if (empty($configurableVariants)) {
+            return;
+        }
+
+        $variantSkus = [];
+
+        foreach ($configurableVariants as $variants) {
+            $variantSkus = array_merge($variantSkus, array_keys($variants));
+        }
+
+        if (empty($variantSkus)) {
+            return;
+        }
+
+        $this->skuStorage->load($variantSkus);
+
+        foreach ($configurableVariants as $parentSku => $variants) {
+            foreach (array_keys($variants) as $variantSku) {
+                if (! $this->skuStorage->get($variantSku)) {
+                    unset($configurableVariants[$parentSku][$variantSku]);
+                }
+            }
+
+            if (empty($configurableVariants[$parentSku])) {
+                unset($configurableVariants[$parentSku]);
+            }
+        }
     }
 
     /**
@@ -144,7 +182,7 @@ class Importer extends BaseImporter
 
         foreach ($imageNames as $key => $image) {
             if (filter_var($image, FILTER_VALIDATE_URL)) {
-                if (array_key_exists('s3', $disks) && $disks['s3']['key'] !== null) {
+                if (array_key_exists('s3', $disks) && ! empty($disks['s3']['key'])) {
                     $parsedUrl = parse_url($image, PHP_URL_PATH);
                     $parsedUrl = ltrim($parsedUrl, '/');
 
@@ -199,7 +237,7 @@ class Importer extends BaseImporter
 
             foreach ($images as $key => $image) {
 
-                if (array_key_exists('s3', $disks) && $disks['s3']['key'] !== null) {
+                if (array_key_exists('s3', $disks) && ! empty($disks['s3']['key'])) {
                     if (Storage::disk('s3')->has($image['name'])) {
                         $productImages[] = [
                             'type'       => 'images',
@@ -218,7 +256,7 @@ class Importer extends BaseImporter
                 } else {
                     $file = new UploadedFile($image['path'], $image['name']);
 
-                    $image = (new ImageManager)->make($file)->encode('webp');
+                    $image = (string) ImageManager::gd()->read($file)->toWebp();
 
                     $imageDirectory = $this->productImageRepository->getProductDirectory((object) $product);
 
@@ -258,7 +296,7 @@ class Importer extends BaseImporter
             return null;
         }
 
-        $image = (new ImageManager)->make(file_get_contents($tempFilePath))->encode('webp');
+        $image = (string) ImageManager::gd()->read(file_get_contents($tempFilePath))->toWebp();
 
         $path = $path.'/'.basename($url);
 


### PR DESCRIPTION
Compatibility with Bagisto 2.4.x and the UnoPim 2.1.x connector. Fixes: exception handler method visibility (private → protected), product image import (S3 empty-key guard + Intervention Image v3), and configurable variant resolution in the bulk import.